### PR TITLE
Fix null body bug

### DIFF
--- a/src/apicalls.ts
+++ b/src/apicalls.ts
@@ -84,13 +84,15 @@ const endRequest = (component: any) => {
 const utf8Encode = (data: string, request: XMLHttpRequest) => {
     let blob: Blob = new Blob([data]);
     let reader: FileReader = new FileReader();
-    var sendable_blob: Uint8Array = null;
-    if (reader.result instanceof ArrayBuffer){
-        sendable_blob = new Uint8Array(<ArrayBuffer>sendable_blob);
-    } else {
-        sendable_blob = new TextEncoder().encode(<string>reader.result);
-    }
-    reader.onloadend = () => request.send(sendable_blob);
+    reader.onloadend = () => {
+        var sendable_blob: Uint8Array = null;
+        if (reader.result instanceof ArrayBuffer){
+            sendable_blob = new Uint8Array(<ArrayBuffer>reader.result);
+        } else {
+            sendable_blob = new TextEncoder().encode(<string>reader.result);
+        }
+        request.send(sendable_blob)
+    };
     reader.readAsArrayBuffer(blob);
 };
 

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -68,6 +68,88 @@ module Endpoints {
         },
         new Utils.TextParam("query", true)
     );
+    const cloud_docs_get_content_endpt = new Utils.Endpoint("cloud_docs", "get_content",
+        {
+            allow_app_folder_app: "True",
+            is_cloud_doc_auth: "True",
+            is_preview: "True",
+            select_admin_mode: "None",
+            style: "download",
+            auth: "user",
+            host: "content",
+            scope: "None",
+        },
+        new Utils.TextParam("file_id", false)
+    );
+    const cloud_docs_get_metadata_endpt = new Utils.Endpoint("cloud_docs", "get_metadata",
+        {
+            allow_app_folder_app: "False",
+            is_cloud_doc_auth: "True",
+            is_preview: "False",
+            select_admin_mode: "None",
+            style: "rpc",
+            auth: "user",
+            host: "api",
+            scope: "files.metadata.read",
+        },
+        new Utils.TextParam("file_id", true)
+    );
+    const cloud_docs_lock_endpt = new Utils.Endpoint("cloud_docs", "lock",
+        {
+            allow_app_folder_app: "False",
+            is_cloud_doc_auth: "True",
+            is_preview: "False",
+            select_admin_mode: "None",
+            style: "rpc",
+            auth: "user",
+            host: "api",
+            scope: "files.metadata.write",
+        },
+        new Utils.TextParam("file_id", true)
+    );
+    const cloud_docs_rename_endpt = new Utils.Endpoint("cloud_docs", "rename",
+        {
+            allow_app_folder_app: "False",
+            is_cloud_doc_auth: "True",
+            is_preview: "False",
+            select_admin_mode: "None",
+            style: "rpc",
+            auth: "user",
+            host: "api",
+            scope: "files.metadata.write",
+        },
+        new Utils.TextParam("file_id", true),
+        new Utils.TextParam("title", true)
+    );
+    const cloud_docs_unlock_endpt = new Utils.Endpoint("cloud_docs", "unlock",
+        {
+            allow_app_folder_app: "False",
+            is_cloud_doc_auth: "True",
+            is_preview: "False",
+            select_admin_mode: "None",
+            style: "rpc",
+            auth: "user",
+            host: "api",
+            scope: "files.metadata.write",
+        },
+        new Utils.TextParam("file_id", true)
+    );
+    const cloud_docs_update_content_endpt = new Utils.Endpoint("cloud_docs", "update_content",
+        {
+            allow_app_folder_app: "True",
+            is_cloud_doc_auth: "True",
+            is_preview: "True",
+            select_admin_mode: "None",
+            style: "upload",
+            auth: "user",
+            host: "content",
+            scope: "None",
+        },
+        new Utils.FileParam(),
+        new Utils.TextParam("file_id", false),
+        new Utils.ListParam("actor_tokens", false, (index: string): Utils.Parameter => new Utils.TextParam(index, false)),
+        new Utils.ListParam("additional_contents", true, (index: string): Utils.Parameter => new Utils.StructParam(index, false, [new Utils.UnionParam("purpose", false, [new Utils.VoidParam("search"), new Utils.VoidParam("preview")]), new Utils.TextParam("content_key", false)]))
+    );
     const contacts_delete_manual_contacts_endpt = new Utils.Endpoint("contacts", "delete_manual_contacts",
         {
             allow_app_folder_app: "False",
@@ -2289,7 +2371,7 @@ module Endpoints {
         {
             allow_app_folder_app: "False",
             is_cloud_doc_auth: "False",
-            is_preview: "True",
+            is_preview: "False",
             select_admin_mode: "None",
             style: "rpc",
             auth: "team",
@@ -2302,7 +2384,7 @@ module Endpoints {
         {
             allow_app_folder_app: "False",
             is_cloud_doc_auth: "False",
-            is_preview: "True",
+            is_preview: "False",
             select_admin_mode: "None",
             style: "rpc",
             auth: "team",
@@ -2315,7 +2397,7 @@ module Endpoints {
         {
             allow_app_folder_app: "False",
             is_cloud_doc_auth: "False",
-            is_preview: "True",
+            is_preview: "False",
             select_admin_mode: "None",
             style: "rpc",
             auth: "team",
@@ -2738,6 +2820,12 @@ module Endpoints {
                                                    auth_token_revoke_endpt,
                                                    check_app_endpt,
                                                    check_user_endpt,
+                                                   cloud_docs_get_content_endpt,
+                                                   cloud_docs_get_metadata_endpt,
+                                                   cloud_docs_lock_endpt,
+                                                   cloud_docs_rename_endpt,
+                                                   cloud_docs_unlock_endpt,
+                                                   cloud_docs_update_content_endpt,
                                                    contacts_delete_manual_contacts_endpt,
                                                    contacts_delete_manual_contacts_batch_endpt,
                                                    file_properties_properties_add_endpt,

--- a/src/main.ts
+++ b/src/main.ts
@@ -750,10 +750,12 @@ class RequestArea extends react.Component<RequestAreaProps, any> {
     }
     updateParamValues = (paramVals: Dict, fileVals: Dict) => {
         this.setState({paramVals: paramVals, fileVals: fileVals});
+        this.forceUpdate();
     };
 
     updateHeaderValues = (headerVals: Header[]) => {
         this.setState({headerVals: headerVals});
+        this.forceUpdate();
     };
 
     updateTokenValue = (tokenValue: string) => {
@@ -855,7 +857,7 @@ class RequestArea extends react.Component<RequestAreaProps, any> {
                                 )
                             ),
                             ce('table', {id: 'parameter-list'},
-                                ce('body', null,
+                                ce('tbody', null,
                                     this.props.currEpt.params.map((param: Parameter) =>
                                         ParamClassChooser.getParamInput(param, {
                                             key:      this.props.currEpt.name + param.name,


### PR DESCRIPTION
- Previous flow before version update tried to send a fileReader's result when it finished reading and in order to fix typing errors, this logic was pulled out in front.  This caused the result attribute of the request to always be null when it was being read.  
- Moved the typing code into the onloadend lambda to mitigate