### PR TITLE
Disable highlighting to fix update bug

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -622,13 +622,15 @@ export class Highlight extends react.Component<HltProps, {}> {
         super(props);
     }
     defaultProps = {className: ""};
-    componentDidMount = () => this.highlightCode();
-    componentDidUpdate = () => this.highlightCode();
 
-    highlightCode = () => [].forEach.call(
-        (<Element>reactDom.findDOMNode(this)).querySelectorAll('pre code'),
-            (node: Node) => hljs.highlightBlock(node)
-    );
+    // TODO: fix this highlighting it breaks updates
+    // componentDidMount = () => this.highlightCode();
+    // componentDidUpdate = () => this.highlightCode();
+
+    // highlightCode = () => [].forEach.call(
+    //     (<Element>reactDom.findDOMNode(this)).querySelectorAll('pre code'),
+    //         (node: Node) => hljs.highlightBlock(node)
+    // );
 
     public render() {
         return react.createElement('pre', {className: this.props.className},


### PR DESCRIPTION
Upon updating a parameter or the code view type, the request view should re-render and show the updated request it is making. However, due to changes in the way react has been updated possibly in #13 this stopped working.

After spending a few hours on this bug. I realized that the fault lies with the highlight js library. Disabling highlighting fixes things. We should fix highlighting but this is a strictly better state than it not working. :) 

[Before](https://www.dropbox.com/s/56hi2p91aqm8meh/Screenshot%202020-07-08%2018.54.42.png?dl=0)
[After](https://www.dropbox.com/s/xsf7mfyobszu8hw/Screenshot%202020-07-08%2018.54.00.png?dl=0)

