### PR TITLE
Use SDK Updater for automated spec updates

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -6,14 +6,32 @@ on:
     types: [spec_update]
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-api-v2-explorer-repo
+          aws-region: us-west-2
+      - name: Fetch GitHub App credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            SDK_UPDATER,sdk-updater-github-app
+          parse-json-secrets: true
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ env.SDK_UPDATER_CLIENT_ID }}
+          private-key: ${{ env.SDK_UPDATER_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -64,18 +82,44 @@ jobs:
           npm run typecheck
           npm test
           npm run build
+      - name: Close old spec update pull requests
+        id: close-old-prs
+        if: steps.update-spec.outputs.has-changes == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          closed=""
+          while read -r pr_num; do
+            echo "Closing old PR #$pr_num"
+            gh pr close "$pr_num" --delete-branch
+            closed="${closed:+$closed,}$pr_num"
+          done < <(
+            gh pr list --state open --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("spec_update_")) | .number'
+          )
+          echo "closed=$closed" >> "$GITHUB_OUTPUT"
       - name: Create pull request
+        id: create-pr
         if: steps.update-spec.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.SPEC_UPDATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: ${{ steps.update-spec.outputs.commit-message }}
           branch: ${{ steps.update-spec.outputs.branch }}
           delete-branch: true
           title: Automated Spec Update
           body: ${{ steps.update-spec.outputs.commit-message }}
           base: main
-          team-reviewers: |
-            owners
-            maintainers
+          labels: automated-spec-update
           draft: false
+      - name: Comment on closed pull requests
+        if: steps.create-pr.outputs.pull-request-number && steps.close-old-prs.outputs.closed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          IFS=',' read -ra prs <<< "${{ steps.close-old-prs.outputs.closed }}"
+          for pr_num in "${prs[@]}"; do
+            gh pr comment "$pr_num" \
+              --body "Superseded by #${{ steps.create-pr.outputs.pull-request-number }}"
+          done


### PR DESCRIPTION
## Summary

- replace the missing `SPEC_UPDATE_TOKEN` with the SDK Updater GitHub App token flow
- authenticate to AWS through repository-scoped OIDC and load the App credentials from Secrets Manager
- close superseded `spec_update_*` pull requests and label new automated updates
- update checkout to v7

## Why

The Spec Update workflow successfully generated and validated the latest API spec, but failed to create its pull request because `SPEC_UPDATE_TOKEN` was not configured. This applies the authentication and PR-management pattern introduced by `dropbox/dropbox-sdk-go-unofficial@924ad8f`.

## Validation

- `actionlint` passes after ignoring its stale metadata warning for the proven `actions/create-github-app-token@v3` `client-id` input
- `git diff --check`

## Test plan

- [x] Confirm the repository-scoped AWS OIDC role exists and can read `sdk-updater-github-app`
- [x] Confirm the SDK Updater GitHub App is installed for this repository
- [x] Run the workflow manually on this branch and verify AWS authentication and App token generation
- [x] After merge and the next spec change, verify an `automated-spec-update` PR is opened and CI runs
