### PR TITLE
Fix HTTP Host header example

### DIFF
--- a/src/codeview.ts
+++ b/src/codeview.ts
@@ -197,7 +197,7 @@ const HTTPCodeViewer = (): CodeViewer => {
   const httpTemplate = (endpt: utils.Endpoint, headers: utils.Dict,
     body: string): react.ReactElement<Record<string, unknown>> => syntaxHighlight(syntax, ce('span', null,
     `POST ${endpt.getPathName()}\n`,
-    `Host: https://${endpt.getHostname()}\n`,
+    `Host: ${endpt.getHostname()}\n`,
     'User-Agent: api-explorer-client\n',
     utils.Dict.map(headers, (key: string, value: string) => ce('span', { key },
       `${key}: ${value}\n`)),

--- a/test/unit/codeview.test.ts
+++ b/test/unit/codeview.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { formats } from '../../src/codeview';
+import { Endpoint } from '../../src/utils';
+
+test('HTTP code view renders a hostname without a URL scheme', () => {
+  const endpoint = new Endpoint('users', 'get_current_account', {
+    auth: 'user',
+    host: 'api',
+    style: 'rpc',
+  });
+
+  const request = renderToStaticMarkup(
+    formats.http.renderRPCLike(endpoint, '<ACCESS_TOKEN>', {}, []),
+  );
+
+  assert.match(request, /Host: api\.dropboxapi\.com\n/);
+  assert.doesNotMatch(request, /Host: https:\/\//);
+});


### PR DESCRIPTION
## Summary
- remove the URL scheme from the generated HTTP Host header
- add regression coverage for the rendered HTTP request

## Why
HTTP Host header values contain only the authority hostname, not a URL scheme. The explorer currently generates `Host: https://api.dropboxapi.com`, which is invalid.

This supersedes #4 and preserves the fix originally proposed by @cakoose.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`