### PR TITLE
Enable automerge for automated spec update PRs

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -123,3 +123,9 @@ jobs:
             gh pr comment "$pr_num" \
               --body "Superseded by #${{ steps.create-pr.outputs.pull-request-number }}"
           done
+      - name: Enable Pull Request Automerge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW_PR: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "$NEW_PR"


### PR DESCRIPTION
Adds an Enable Pull Request Automerge step to the spec-update workflow, matching the SDK repos. Uses `--squash` because `main` requires linear history (merge commits are rejected).

This also resolves the same-day re-dispatch failure: without automerge the generated PR stays open, so a second same-day dispatch closes it + deletes the shared `spec_update_<date>` branch and then races to recreate it (`couldn't find remote ref`). With automerge the PR lands promptly, so a re-dispatch finds no diff and no-ops — the same reason the SDK repos don't hit this.